### PR TITLE
Missing Video for Tutorial

### DIFF
--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -3,6 +3,10 @@
 <h1 id="message"></h1>
 <div class="col col-4">
   <h4>Videos</h4>
+  <!-- < % binding.pry %> -->
+  <% if @facade.videos.empty? %>
+  <p> There are currently no videos available for this tutorial. </p>
+  <% else %>
   <ul>
     <% @facade.videos.each do |video| %>
       <li>
@@ -65,5 +69,5 @@
     <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
   </p>
 </div>
-
+<% end %>
 </main>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+no_video_tutorial_data = {
+  'title' => 'No Video Test',
+  'description' => 'Test tutorial without videos.',
+  'thumbnail' => 'https://img.etimg.com/thumb/msid-69533333,width-643,imgsize-35861,resizemode-4/youtube-on-android-may-get-bigger-better-video-streaming-giant-tests-enlarged-play-cancel-buttons.jpg',
+  'classroom' => false
+}
+no_video_tutorial = Tutorial.create! no_video_tutorial_data
+
+
 prework_tutorial_data = {
   'title' => 'Back End Engineering - Prework',
   'description' => 'Videos for prework.',

--- a/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
+++ b/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
@@ -19,9 +19,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 10 Oct 2019 20:32:48 GMT
+      - Mon, 14 Oct 2019 01:19:50 GMT
       Date:
-      - Thu, 10 Oct 2019 20:32:48 GMT
+      - Mon, 14 Oct 2019 01:19:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Etag:
@@ -118,5 +118,5 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 10 Oct 2019 20:32:48 GMT
+  recorded_at: Mon, 14 Oct 2019 01:19:47 GMT
 recorded_with: VCR 4.0.0

--- a/spec/features/tutorials/tutorial_show_spec.rb
+++ b/spec/features/tutorials/tutorial_show_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'user/visitor visits a tutorial show page' do
+  it 'tutorial without videos displays notice' do
+    tutorial = create(:tutorial)
+    visit '/'
+
+    click_on tutorial.title
+
+    expect(page).to have_content("There are currently no videos available for this tutorial.")
+  end
+end


### PR DESCRIPTION
- If user/visitor visits a tutorial without videos, tutorial show page will show notice 'You watched them all. Bask in the glory of your new skills.' 
- Testing included
- Rspec OK 
- Tested in production 